### PR TITLE
More filecheck cleanup

### DIFF
--- a/src/coreclr/tools/SuperFileCheck/Program.cs
+++ b/src/coreclr/tools/SuperFileCheck/Program.cs
@@ -184,14 +184,25 @@ namespace SuperFileCheck
                 GetDescendantSingleLineCommentTrivia(root)
                 .Where(x =>
                 {
-                    if (x.Token.Parent != null)
-                    {
-                        return !x.Token.Parent.Ancestors().Any(p => p.IsKind(SyntaxKind.MethodDeclaration) && p.Span.Contains(x.Span));
-                    }
-                    else
+                    if (x.Token.Parent == null)
                     {
                         return true;
                     }
+
+                    // A comment before the method declaration is considered a child of the method
+                    // declaration.  In this example:
+                    //
+                    // // trivia1
+                    // public void M()
+                    // {
+                    //     // trivia2
+                    // }
+                    //
+                    // Both // trivia1 and // trivia2 are descendants of MethodDeclarationSyntax.
+                    //
+                    // We are only allowing checks to occur in 'trivia2'.  The 'Contains' check is
+                    // used to find 'trivia1'.
+                    return !x.Token.Parent.Ancestors().Any(p => p.IsKind(SyntaxKind.MethodDeclaration) && p.Span.Contains(x.Span));
                 })
                 .Where(x => ContainsCheckPrefixes(x.ToString(), checkPrefixes))
                 .ToArray();
@@ -243,20 +254,18 @@ namespace SuperFileCheck
             {
                 throw new InvalidOperationException("SourceText is null.");
             }
-            else
+
+            var lineStr = text.ToString(line.Span);
+
+            var result = TryTransformDirective(lineStr, checkPrefixes, SyntaxDirectiveFullLine, String.Empty);
+            if (result != null)
             {
-                var lineStr = text.ToString(line.Span);
-
-                var result = TryTransformDirective(lineStr, checkPrefixes, SyntaxDirectiveFullLine, String.Empty);
-                if (result != null)
-                {
-                    return result;
-                }
-
-                result = TryTransformDirective(lineStr, checkPrefixes, SyntaxDirectiveFullLineNext, "-NEXT");
-
-                return result ?? lineStr;
+                return result;
             }
+
+            result = TryTransformDirective(lineStr, checkPrefixes, SyntaxDirectiveFullLineNext, "-NEXT");
+
+            return result ?? lineStr;
         }
 
         /// <summary>

--- a/src/coreclr/tools/SuperFileCheck/Program.cs
+++ b/src/coreclr/tools/SuperFileCheck/Program.cs
@@ -468,7 +468,7 @@ namespace SuperFileCheck
             Console.Write(Environment.NewLine);
             Console.WriteLine("SUPER OPTIONS:");
             Console.Write(Environment.NewLine);
-            Console.WriteLine($"  --csharp                       - An {CommandLineInputFile} is required.");
+            Console.WriteLine($"  --csharp                       - A {CommandLineInputFile} is required.");
             Console.WriteLine($"                                   <check-file> must be a C# source file.");
             Console.WriteLine($"                                   Methods must not have duplicate names.");
             Console.WriteLine($"                                   Methods must be marked as not inlining.");

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -436,8 +436,7 @@ $(CLRTestBashPostCommands)
     </PropertyGroup>
     <PropertyGroup>
       <BashEnvironmentVariables>
-@(CLRTestBashEnvironmentVariable -> 'export %(Identity)=%(Value)', '%0a')
-@(CLRTestEnvironmentVariable -> 'export %(Identity)=%(Value)', '%0a')
+@(CLRTestBashEnvironmentVariable -> '%(Identity)', '%0a')
       </BashEnvironmentVariables>
     </PropertyGroup>
 
@@ -535,6 +534,7 @@ if [ -n "$__TestEnv" ]%3B then
     source $__TestEnv
 fi
 
+$(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
@@ -543,7 +543,6 @@ $(SuperPMICollectionBashScript)
 # Allow precommands to override the ExePath
 ExePath=$(InputAssemblyName)
 export TestExclusionListPath=$CORE_ROOT/TestExclusionList.txt
-$(BashEnvironmentVariables)
 # PreCommands
 $(BashCLRTestPreCommands)
 # Launch

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -348,8 +348,7 @@ $(CLRTestBatchPostCommands)
     </PropertyGroup>
     <PropertyGroup>
       <BatchEnvironmentVariables>
-@(CLRTestBatchEnvironmentVariable -> 'set %(Identity)=%(Value)', '%0d%0a')
-@(CLRTestEnvironmentVariable -> 'set %(Identity)=%(Value)', '%0d%0a')
+@(CLRTestBatchEnvironmentVariable -> '%(Identity)', '%0d%0a')
       </BatchEnvironmentVariables>
     </PropertyGroup>
 
@@ -435,6 +434,9 @@ IF NOT "%__TestEnv%"=="" (
     )
 )
 
+REM Environment Variables
+$(BatchEnvironmentVariables)
+
 $(BatchCLRTestEnvironmentCompatibilityCheck)
 
 $(IlasmRoundTripBatchScript)
@@ -444,9 +446,6 @@ $(SuperPMICollectionBatchScript)
 REM Allow precommands to override the ExePath
 set ExePath=$(InputAssemblyName)
 set TestExclusionListPath=%CORE_ROOT%\TestExclusionList.txt
-
-REM Environment Variables
-$(BatchEnvironmentVariables)
 
 REM Precommands
 $(CLRTestBatchPreCommands)

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -203,6 +203,11 @@ IF NOT DEFINED DoLink (
     </PropertyGroup>
   </Target>
 
+  <!--
+  The source code file(s) (specified by HasDisasmCheck in the test's project file) contain
+  the patterns used by FileCheck.  They need to be copied to the output directory for the
+  test to be self-contained.
+  -->
   <Target Name="PropagateHasDisasmCheckToCopy"
           BeforeTargets="AssignTargetPaths">
     <ItemGroup>

--- a/src/tests/Common/CLRTest.MockHosting.targets
+++ b/src/tests/Common/CLRTest.MockHosting.targets
@@ -10,8 +10,8 @@ This file contains the logic for correctly hooking up a mock hostpolicy to a tes
   <ItemGroup>
     <CMakeProjectReference Include="$(MSBuildThisFileDirectory)hostpolicymock/CMakeLists.txt" />
     <!-- %28 decodes to '('. It's needed to keep MSBuild from trying to parse $(pwd) as an MSBuild property -->
-    <CLRTestBashEnvironmentVariable Include="MOCK_HOSTPOLICY" Value="$%28pwd)/libhostpolicy" />
+    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/libhostpolicy" />
     <!-- %25 decodes to '%'. It's needed to keep %cd itself from being decoded since we want '%cd%' directly in the script. -->
-    <CLRTestBatchEnvironmentVariable Include="MOCK_HOSTPOLICY" Value="%25cd%\hostpolicy.dll" />
+    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy.dll" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="DllImportPathTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestBashEnvironmentVariable Include="LD_LIBRARY_PATH" Value="$LD_LIBRARY_PATH:$%28pwd)/Subdirectory" />
+    <CLRTestBashEnvironmentVariable Include="export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$%28pwd)/Subdirectory" />
   </ItemGroup>
   <PropertyGroup>
     <PathEnvSetupCommands><![CDATA[

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
@@ -3,10 +3,16 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitNoStructPromotion=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitNoStructPromotion=1
+]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-
-    <CLRTestEnvironmentVariable Include="COMPlus_JitNoStructPromotion" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/Loader/NativeLibs/FromNativePaths.csproj
+++ b/src/tests/Loader/NativeLibs/FromNativePaths.csproj
@@ -14,8 +14,8 @@
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestBashEnvironmentVariable Include="CORE_LIBRARIES" Value="$CORE_LIBRARIES:$%28pwd)/Subdirectory" />
-    <CLRTestBatchEnvironmentVariable Include="CORE_LIBRARIES" Value="$CORE_LIBRARIES%3B%25cd%\\Subdirectory" />
+    <CLRTestBashEnvironmentVariable Include="export CORE_LIBRARIES=$CORE_LIBRARIES:$%28pwd)/Subdirectory" />
+    <CLRTestBatchEnvironmentVariable Include="set CORE_LIBRARIES=$CORE_LIBRARIES%3B%25cd%\\Subdirectory" />
   </ItemGroup>
   <PropertyGroup>
     <PathEnvSetupCommands><![CDATA[


### PR DESCRIPTION
The important thing here is undoing the change to environment variable handling since it is not needed and can be reasoned about (reviewed) separately.  I think the rest is general cleanup.

I haven't yet looked at the diff from super-filecheck + this PR against runtime main.  I'd like to verify that the environment variable changes are all gone.